### PR TITLE
Add commercial docs, update footer and config for site launch

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,5 +18,6 @@ company:
   address: 365 Boston Post Road, Suite 132, Sudbury, MA 01776, USA
   privacy_email: privacy@go2.software
   contact_email: info@go2.software
+  security_email: security@go2.software
 
 copyright_year: 2026

--- a/docs/_includes/site-footer.html
+++ b/docs/_includes/site-footer.html
@@ -3,6 +3,15 @@
 
   <nav class="site-footer__nav" aria-label="Legal and policies">
     <ul>
+      <li><a href="{{ '/pricing.html' | relative_url }}">Pricing</a></li>
+      <li><a href="{{ '/faq.html' | relative_url }}">FAQ</a></li>
+      <li><a href="{{ '/feature_matrix.html' | relative_url }}">Feature Support Matrix</a></li>
+      <li><a href="{{ '/privacy_policy.html' | relative_url }}">Privacy Policy</a></li>
+      <li><a href="{{ '/subscription_terms.html' | relative_url }}">Subscription Terms</a></li>
+      <li><a href="{{ '/subscription_terms.html' | relative_url }}#refund-policy">Refund Policy</a></li>
+      <li><a href="{{ '/free_tier_terms.html' | relative_url }}">Free-Tier Terms</a></li>
+      <li><a href="{{ '/data_processing_addendum.html' | relative_url }}">Data Processing Addendum</a></li>
+      <li><a href="{{ '/security_data_handling.html' | relative_url }}">Security &amp; Data Handling</a></li>
       <li><a href="https://github.com/kennovation1/kenfigure/blob/main/LICENSE">Schema License (ODC-BY)</a></li>
       <li><a href="mailto:{{ site.company.contact_email | default: 'info@go2.software' }}">Contact</a></li>
     </ul>
@@ -14,12 +23,12 @@
   </p>
 
   <p class="site-footer__meta">
-    Kenfigure&trade; and Kenfiguration&trade; are trademarks of Go2 Software LLC.
+    Kenfigure&trade;, Kenfigure Pro&trade;, Kenfigure Tool&trade;, Kenfigure Diagram&trade;, and Kenfiguration&trade; are trademarks of Go2 Software LLC.
     Use of these names in derivative projects, commercial offerings, or branding requires written permission.
   </p>
 
   <p class="site-footer__meta site-footer__meta--muted">
     {{ site.company.legal_name | default: 'Go2 Software LLC' }},
-    {{ site.company.address | default: '365 Boston Post Road, #132, Sudbury, MA 01776, USA' }}
+    {{ site.company.address | default: '365 Boston Post Road, Suite 132, Sudbury, MA 01776, USA' }}
   </p>
 </footer>

--- a/docs/data_processing_addendum.md
+++ b/docs/data_processing_addendum.md
@@ -1,0 +1,77 @@
+---
+title: Kenfigure Data Processing Addendum
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Data Processing Addendum (DPA)
+
+_This DPA forms part of, and is incorporated by reference into, the [Kenfigure Subscription Terms](subscription_terms.html) between Go2 Software LLC ("Provider," "Processor") and the customer named on the Order Form ("Customer," "Controller"). If it conflicts with the Subscription Terms on data-protection matters, this DPA controls._
+
+---
+
+## 1. Scope and the nature of the data
+
+A defining feature of the Service is that it operates on **Benchling configuration schema — the structure of a deployment — not on scientific, research, clinical, sample, or patient data.** The Service is neither designed for nor intended to process special categories of personal data, and Customer agrees not to use it to do so.
+
+The only personal data the Service processes is **limited business contact and account information** about Customer's authorized users — names, business email addresses, company affiliation, role, and Benchling tenant identifiers — for the purpose of providing the Service. Customer is the controller of this personal data; Provider is the processor.
+
+| | |
+|---|---|
+| Subject matter | Provision of the Kenfigure Pro™ Service |
+| Duration | The subscription term, plus any wind-down period |
+| Nature and purpose | Hosting and processing configuration data and account information to provide Kenfigure Tool™ (Export/Import) and Kenfigure Diagram™ features and related support |
+| Personal data | Authorized users' names, business emails, company, role, tenant identifiers |
+| Data subjects | Customer's authorized users and administrators |
+
+## 2. Processing instructions
+
+Provider will process personal data only on Customer's documented instructions, including those in the Agreement and this DPA, and as required by applicable law (in which case Provider will inform Customer unless legally prohibited). Provider will promptly tell Customer if, in its opinion, an instruction infringes applicable data-protection law.
+
+## 3. Confidentiality
+
+Provider ensures that personnel authorized to process personal data are bound by appropriate confidentiality obligations.
+
+## 4. Security
+
+Provider maintains reasonable technical and organizational measures designed to protect personal data, as summarized in the [Kenfigure Security & Data Handling Overview](security_data_handling.html), including access controls, multi-factor authentication for administrative access, encryption in transit, and least-privilege access.
+
+## 5. Personal data breaches
+
+Provider will notify Customer without undue delay after becoming aware of a personal-data breach affecting Customer's personal data, and will provide information reasonably available to help Customer meet its own notification obligations.
+
+## 6. Subprocessors
+
+Customer authorizes Provider to engage subprocessors to support the Service. Current subprocessors are:
+
+- **Amazon Web Services** (hosting, including Amazon Bedrock for the AI grouping feature) — Amazon Bedrock does not use the data to train models and does not retain it.
+- **Paddle** (Paddle.com Market Ltd. — payment processing and billing; Merchant of Record / seller of record).
+- **Fastmail Pty Ltd** (go2.software transactional and order-processing email).
+- **Forward Email LLC** (kenfigure.com account and password-reset emails).
+
+Provider imposes data-protection obligations on each subprocessor that are no less protective than those in this DPA, and remains responsible for their performance. Provider will give Customer notice of any intended new subprocessor and a reasonable opportunity to object on reasonable data-protection grounds.
+
+## 7. International transfers
+
+Where Provider processes personal data subject to EU or UK data-protection law and transfers it to the United States or another country, the parties will rely on an appropriate transfer mechanism, such as the Standard Contractual Clauses, which are incorporated by reference where applicable.
+
+## 8. Assistance and data-subject rights
+
+Taking into account the nature of the processing, Provider will provide reasonable assistance to help Customer respond to data-subject requests and to meet Customer's obligations regarding security, breach notification, and data-protection impact assessments. Provider will forward to Customer any data-subject request it receives directly that relates to Customer's data.
+
+## 9. Audit
+
+Provider will make available information reasonably necessary to demonstrate compliance with this DPA, including responses to a reasonable security questionnaire and relevant documentation, no more than once per year and subject to confidentiality.
+
+## 10. Return and deletion
+
+On termination of the subscription, Provider will delete or return Customer's personal data within a reasonable period, except where retention is required by law. Configuration data copies held by the Service are transient and are removed when the subscription ends.
+
+## 11. CCPA
+
+To the extent the California Consumer Privacy Act applies, Provider acts as a "service provider" and will not sell or share personal information, and will not retain, use, or disclose it except as necessary to provide the Service or as permitted by law.
+
+## 12. Liability
+
+Each party's liability under this DPA is subject to the limitation of liability in the [Subscription Terms](subscription_terms.html).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,142 @@
+---
+title: Kenfigure Pro FAQ
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Pro™ — Frequently Asked Questions
+
+_Go2 Software LLC · [info@go2.software](mailto:info@go2.software)_
+
+---
+
+## Getting started
+
+**What is Kenfigure Pro and what problem does it solve?**
+
+Benchling configuration — entity schemas, dropdowns, result schemas, and more — is complex, evolves constantly, and exists only as clicks in a UI. Kenfigure Pro brings that configuration under version control: export it to reviewable, auditable YAML; propose and review changes in Git; import them to Benchling precisely; and explore the resulting schema through interactive diagrams. The result is the same configuration-management discipline software teams apply to code, now applied to your Benchling platform.
+
+**Do I need a developer or DevOps engineer to use Kenfigure Pro?**
+
+No. Kenfigure Pro runs as a Benchling Canvas app — there is no infrastructure to set up or maintain on your end. A Benchling administrator can run the full workflow. Configuration files are YAML — human-readable text that uses the same labels and values you see in the Benchling UI, not code — and Kenfigure Diagram™ makes the schema visually explorable by any user without opening a file. Familiarity with Git is helpful, but not required since Git integration is optional.
+
+**What Benchling tenant types are supported?**
+
+Kenfigure Pro works with the standard Benchling enterprise platform. Validated Cloud tenants are fully supported. Kenfigure Pro is not applicable for academic tenants.
+
+**How do I get started?**
+
+Choose your tier on the [pricing page](pricing.html) and complete the [order form](https://auth.kenfigure.com/order). We provision your account once your order is placed — you do not have to wait for payment to clear. The free **Kenfigure Tool™ (Export)** is available to anyone immediately with no order form required: install the Benchling Canvas app and export. See the [Kenfigure Tool User Guide](./kenfigure_tool_user_guide.md) for details and installation instructions.
+
+---
+
+## Pricing and licensing
+
+**How is my pricing tier determined?**
+
+We use your organization's total Benchling user count as a proxy for the scale and complexity of your Benchling deployment. Your tier reflects that scale — it is not a per-seat charge, and has nothing to do with how many people will use Kenfigure Pro directly.
+
+**How many people can use Kenfigure Pro?**
+
+As many as you need. Kenfigure Pro is a **company-wide license** — there is no per-seat fee and no cap on the number of logins you can provision. Every administrator, reviewer, and scientist who needs access can have an account.
+
+**Does a Kenfigure Diagram user need to be a Benchling user?**
+
+No. A Kenfigure Diagram user has a unique Kenfigure Pro login, and they need not also have a Benchling account. This is particularly helpful for computational or data scientists who need to understand the data model but don't need to consume a Benchling user seat.
+
+**Does Kenfigure Pro cover all of our Benchling tenants?**
+
+Yes — all of them. One subscription covers every Benchling environment in your organization: Dev, Test, Prod, Sandbox, Preview, and any others. You pay once for your organization, not once per environment.
+
+**We're a startup. Is it too early to use Kenfigure Pro?**
+
+The best time to establish good configuration management practice is at the very beginning, before things get complicated. Your science will evolve constantly, and so will your Benchling configuration. Starting with a versioned source of truth means every change is documented, reviewed, auditable, and safely promotable from day one. Starting without one means accumulating configuration debt: schemas with undetected quality issues, structural duplications that become load-bearing, and change habits that are far harder to reform later than to build correctly from the start. Closing the barn door after the horses have left is possible — but considerably more painful. That's why we offer the sharply discounted Startup tier to make starting early easy.
+
+**Can I commit to multiple years to lock in pricing?**
+
+Yes. A 2-year prepay earns **10% off** the annual rate; a 3-year prepay earns **15% off**. Both prepays lock the price for the full committed term. After the term, the subscription renews annually at then-current pricing.
+
+**Is there a free trial?**
+
+The free **Kenfigure Tool (Export)** is available to every Benchling customer at no charge and requires no order form. Export your configuration, review the schema-lint output, and explore the YAML — all before committing to Kenfigure Pro.
+
+---
+
+## Features and coverage
+
+**What types of Benchling configuration objects are supported?**
+
+The vast majority of Benchling configuration objects are supported. Some object types have partial coverage across export, import, and diagram. See the full [Feature Support Matrix](feature_matrix.html) for complete coverage by object type and feature.
+
+**How is Kenfigure Pro different from just using Benchling's Configuration Migration tool?**
+
+Benchling's Configuration Migration tool is the mechanism for applying changes — Kenfigure Pro is the discipline around that mechanism. Without Kenfigure Pro, the source of a configuration change is a person clicking through the Benchling UI: undocumented, unreviewed, unversioned, and unrepeatable. With Kenfigure Pro, every change originates in YAML, optionally goes through a pull request, and is applied precisely and auditably via Benchling's own tool. Kenfigure Pro doesn't replace Configuration Migration; it makes every use of it intentional and traceable.
+
+**Does Kenfigure Pro support Benchling Validated Cloud?**
+
+Yes, fully. Kenfigure Pro works with Validated Cloud tenants and is built around the GxP promotion pattern: edit in Git, approve with a pull request, import to Preview (or Sandbox), validate, and promote to Prod via Configuration Migration — with a complete audit trail at each step.
+
+**How does Kenfigure Diagram work?**
+
+Kenfigure Diagram is a web-based interactive entity-relationship diagram of your Benchling configuration. It lets you visualize and navigate complex schema relationships, see schema-lint findings in context, search across schema elements, and use the Prompt Builder to generate SQL queries and AI starting points from selected elements. Layouts, groupings, and lint suppressions can be saved to your Git repository so the diagram state is versioned alongside your configuration. When backed by Git, the diagram reflects the current state of your branch in real time — changes committed to Git are immediately visible in the diagram, even before they have been imported to Benchling.
+
+**What is the Git integration and what does it add?**
+
+The free **Kenfigure Tool (Export)** can already write exports directly to your Git repository. **Kenfigure Pro** extends this in both directions: **Kenfigure Tool (Import)** reads configuration YAML from a Git branch as the source for an import, and **Kenfigure Diagram** reads from and writes to your repository — persisting layouts, sub-layouts, and schema-lint suppressions to a branch of your choice. Git becomes the connective tissue across the entire workflow. When writing back to Git you can configure a direct commit to the branch head or an automatic pull request for review. Git usage is optional, but highly recommended.
+
+**What is "schema lint"?**
+
+Schema lint is a set of heuristic rules that flag risky anti-patterns in your Benchling configuration. These rules are based on years of Go2 Software's experience developing highly effective data models in Benchling. During export and import operations a log file of schema lint warnings is produced. Additionally, **Kenfigure Diagram** provides easy visualization of schema issues using a squiggle underline — like a spell checker — to show which schemas or fields have warnings. An interactive panel lets you sort, filter, and selectively suppress warnings that are acceptable in your context.
+
+---
+
+## Security and compliance
+
+**Does Kenfigure Pro access our scientific, research, clinical, or patient data?**
+
+No. Kenfigure Pro operates exclusively on Benchling configuration schema — the structure of your deployment. It does not access, store, or process your scientific, research, experimental, sample, clinical, or patient data. See our [Security & Data Handling Overview](security_data_handling.html).
+
+**How is our data secured?**
+
+The Service runs on Amazon Web Services infrastructure dedicated to Kenfigure Pro, with encryption in transit (TLS) and at rest (AWS-managed), MFA for all administrative access, and least-privilege access controls throughout. Any Git token you provide is secured through Benchling's native Canvas secure-configuration capability and is never stored or transmitted in plain text. Full details are in our [Security & Data Handling Overview](security_data_handling.html).
+
+**Does Kenfigure Pro comply with GDPR?**
+
+We process only limited business contact information about authorized users (name, business email, company, role, Benchling tenant identifiers). For personal data subject to EU or UK data-protection law, we rely on Standard Contractual Clauses as the transfer mechanism. Details are in our [Privacy Policy](privacy_policy.html) and [Data Processing Addendum](data_processing_addendum.html).
+
+---
+
+## Support and services
+
+**What support is included with Kenfigure Pro?**
+
+Email support is included. Expect a prompt, substantive response from someone who knows Kenfigure deeply — not a tier-1 support queue. Contact [info@go2.software](mailto:info@go2.software).
+
+**Is training available?**
+
+Kenfigure Pro is designed to be intuitive, and online resources and video walkthroughs are available to help you get up and running quickly. For organizations that want a more guided experience — hands-on training, best practices for Git-based configuration management, or a structured walk-through of the end-to-end promotion workflow — Go2 Software offers targeted training engagements. [Contact us](mailto:info@go2.software) to discuss your team's needs.
+
+**Does Go2 Software offer consulting?**
+
+Yes — two flavors.
+
+**Kenfigure Pro consulting:** best practices for Kenfigure Pro, Git-based configuration management workflows, and establishing high-quality change management discipline in Benchling.
+
+**Benchling platform consulting:** Ken Robbins of Go2 Software brings deep Benchling platform expertise to engagements of every scale — from leading full digital transformation initiatives and building out new scientific use cases, to targeted work such as data model design or refactoring, platform assessments, schema audits, and creating configuration or data clones of production environments. Learn more at [go2.software](https://go2.software) or [contact us](mailto:info@go2.software).
+
+---
+
+## Other questions
+
+**What is the free Kenfigure Tool (Export) and how does it differ from Kenfigure Pro?**
+
+**Kenfigure Tool (Export)** is free to any Benchling customer with no subscription required beyond installing the Canvas app. It exports your Benchling configuration to Kenfigure YAML — as a downloadable zip or written directly to your Git repository — and includes schema-lint analysis. Kenfigure Pro adds **Kenfigure Tool (Import)** (push reviewed changes back to Benchling from your YAML) and **Kenfigure Diagram** (interactive schema visualization with Git-backed state). See [Pricing](pricing.html) and [Free-Tier Terms](free_tier_terms.html).
+
+**My question isn't answered here.**
+
+[Contact us](mailto:info@go2.software) — we're happy to help!
+
+---
+
+[Back to Kenfigure home](https://kenfigure.com)

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -1,0 +1,58 @@
+---
+title: Kenfigure Feature Support Matrix
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Feature Support Matrix
+
+Top-level Kenfigure object types from the [Kenfigure JSON schema](https://kenfigure.com/jsonschemas/latest/kenfigure.schema.json) and their support in Kenfigure Tool and Kenfigure Diagram.
+
+| Object type | Export | Import | Diagram | Notes |
+|-------------|--------|--------|---------|-------|
+| Dropdowns | ✓ | ✓ | ✓ | |
+| Entity schemas | ✓ | ✓ | ✓ | |
+| Fieldset schemas | ✓ | ✓ | ✓ | |
+| Result schemas | ✓ | ✓ | ✓ | |
+| Study schemas | ✓ | ✓ | ✓ | |
+| Location schemas | ✓ | ✓ | ✓ | |
+| Container schemas | ✓ | ✓ | ✓ | |
+| Box schemas | ✓ | ✓ | ✓ | |
+| Plate schemas | ✓ | ✓ | ✓ | |
+| Run schemas | ✓ | ✓ | X | |
+| Dashboards | ✓ | X | N/A | Export is via API since dashboards are not supported by Configuration Migration |
+| Template collections | ✓ | ✓ | N/A | |
+| Templates | ✓ | X | N/A | |
+| Sub templates | ✓ | X | N/A | |
+| Instrument gateways | X | X | X | |
+| Connection schemas | N/A | N/A | X | |
+| Connections | X | X | N/A | |
+| Feature flags | X | N/A | N/A | |
+| Workflow schemas | X | X | X | No JSON schema support |
+
+**Key**
+
+| Symbol | Meaning |
+|--------|---------|
+| ✓ | Supported |
+| X | Not supported |
+| N/A | Not applicable to this feature |
+
+- **Export** — Benchling → Kenfigure YAML
+- **Import** — Kenfigure YAML → Benchling (via Benchling's Configuration Migration tool)
+- **Diagram** — rendered in Kenfigure Diagram
+
+## Notes
+
+**Configuration Migration scope.** Kenfigure Tool Export and Import are both bounded by what Benchling's Configuration Migration tool supports. Objects outside that scope — such as Access Policies — are not exportable or importable. Dashboard exports is an exception since we use the API to fetch dashboard definitions.
+
+**Pass-through elements.** Some data elements within supported object types (e.g., computed/snapshot schema fields and input/output file transformations in Run schemas) are mapped 1:1 from Benchling without Kenfigure JSON schema validation. These elements can be round-tripped (exported and re-imported) but cannot be created from scratch via import — they must originate from an existing Benchling configuration. They are not intended for manual editing.
+
+**Deprecated features.** Deprecated Benchling object types (e.g., legacy Batch schemas) are not supported. Export and import will not function if your configuration has dependencies on deprecated features.
+
+**Unlisted object types.** Object types not listed above are not supported in the Kenfigure JSON schema. If an object type you need is missing, please [contact us](mailto:info@go2.software)!
+
+---
+
+[Back to Kenfigure home](https://kenfigure.com)

--- a/docs/free_tier_terms.md
+++ b/docs/free_tier_terms.md
@@ -1,0 +1,52 @@
+---
+title: Kenfigure Free-Tier Terms
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Free-Tier Terms
+
+_Last updated: June 2026. Go2 Software LLC, 365 Boston Post Road, Suite 132, Sudbury, MA 01776, USA, [info@go2.software](mailto:info@go2.software). Kenfigure is a product of Go2 Software LLC._
+
+---
+
+## 1. What this covers
+
+These Free-Tier Terms govern your use of **Kenfigure Tool™ (Export)** (the "**Free Tool**") — the export feature provided through the Kenfigure Benchling Canvas app, including its schema-lint output. The paid **Kenfigure Pro™** subscription (Kenfigure Tool (Import) and Kenfigure Diagram™) is governed separately by the [Kenfigure Pro Subscription Terms](subscription_terms.html). By using the Free Tool, you agree to these terms.
+
+## 2. License and use
+
+We grant you a free, non-exclusive, non-transferable, revocable right to use the Free Tool for your internal business purposes of managing your Benchling configuration. The Free Tool operates on Benchling configuration schema (the structure of your deployment), not scientific, research, clinical, or patient data.
+
+## 3. Your information
+
+When you use the Free Tool, we receive the email address associated with your use, along with limited usage information. We handle this in accordance with our [Privacy Policy](privacy_policy.html). We may send you occasional account or product communications, and you can opt out of non-essential messages at any time.
+
+## 4. Git repositories (optional)
+
+If you direct the Free Tool to export to your own Git repository, you provide a limited-scope access token that you control, secured through Benchling's native Canvas capabilities. You set its scope and duration and can revoke it at any time. You are responsible for your repository and for complying with the terms of Benchling and your repository provider.
+
+## 5. Acceptable use
+
+You will not: (a) resell or provide the Free Tool to third parties as a service; (b) reverse engineer or attempt to derive source code, except where that restriction is prohibited by law; (c) use the Free Tool to build a competing product; (d) interfere with or place unreasonable load on the service; or (e) use it unlawfully or to infringe others' rights.
+
+## 6. No warranty
+
+The Free Tool is provided "**AS IS**," without warranty of any kind, and without any support or availability commitment. We may modify, suspend, or discontinue the Free Tool, in whole or in part, at any time without liability.
+
+## 7. Limitation of liability
+
+To the maximum extent permitted by law, we will not be liable for any indirect, incidental, special, consequential, or punitive damages, or for lost profits or data, arising from your use of the Free Tool; and our total liability relating to the Free Tool will not exceed one hundred U.S. dollars ($100).
+
+## 8. Intellectual property
+
+We own all right, title, and interest in the Free Tool and related software. The open Kenfigure standard is licensed separately under its own open-source license.
+
+## 9. Termination
+
+We may suspend or end your access to the Free Tool at any time. You may stop using it at any time.
+
+## 10. General
+
+These terms are governed by the laws of the Commonwealth of Massachusetts. We may update them and will post the revised version with a new date; continued use means you accept the changes. Questions: [info@go2.software](mailto:info@go2.software).

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,0 +1,133 @@
+---
+title: Kenfigure Pricing
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Pricing
+
+_Kenfigure is a product of Go2 Software LLC · Last updated: June 2026_
+
+Kenfigure helps Benchling administrators bring their configuration under control — export it to a versionable source of truth, make reviewed changes safely, and understand complex deployments through interactive diagrams. The free **Kenfigure Tool™ (Export)** is available to everyone. **Kenfigure Pro™** adds **Kenfigure Tool (Import)** and **Kenfigure Diagram™** on an annual subscription.
+
+<style>
+.pricing-order-btn {
+  display: inline-block; margin: 1rem 0;
+  padding: 0.75rem 2rem; background: #27ae60; color: #fff;
+  border-radius: 4px; font-size: 1rem; font-weight: bold; text-decoration: none;
+}
+.pricing-order-btn:hover { background: #219a52; color: #fff; }
+</style>
+
+<a href="https://auth.kenfigure.com/order" class="pricing-order-btn">Order Kenfigure Pro →</a>
+
+---
+
+## Free — Kenfigure Tool (Export)
+
+**$0. No sign-up beyond the Benchling app install.**
+
+- Export your Benchling configuration to Kenfigure format — either as a downloadable **.zip that expands to a directory tree of Kenfigure-format YAML files**, or written **directly to your own Git repository** as that same directory tree (via a direct commit or a pull request).
+- Includes **schema lint**: heuristic quality checks that flag potential configuration issues.
+- Runs as a Benchling Canvas app inside your Benchling tenant.
+
+Export gives you an independent, version-controllable source of truth for a configuration that otherwise lives only as UI clicks. Use of the **Kenfigure Tool (Export)** is governed by the [Free-Tier Terms](free_tier_terms.html).
+
+---
+
+## Kenfigure Pro
+
+A single per-company subscription that **covers all of your Benchling environments** (Dev, Test, Prod, and any Sandbox/Preview tenants). Pricing is based on your total Benchling user count.
+
+| Tier | Benchling users | Annual price (USD) |
+|---|---|---|
+| **Startup** | up to 20 | **$2,900** |
+| **Standard** | up to 100 | **$6,500** |
+| **Growth** | 101–200 | **$13,000** |
+| **Enterprise** | 200+ | **Custom — from $19,500** |
+
+_Tier is based on your **organization's total Benchling user count** — the total number of users in your company on Benchling, not the number of people who will use Kenfigure directly._
+
+Prices are per company, billed annually.
+
+### What's included in Pro
+
+_Everything in the free **Kenfigure Tool (Export)** tier, plus:_
+
+- **Kenfigure Tool (Import)** — push configuration changes back to Benchling directly from your Kenfigure YAML. Because every change originates from a versioned, reviewed, and approved source of truth, there is no manual clicking through the Benchling UI — imports are accurate, auditable, and far faster than equivalent manual work.
+- **Kenfigure Diagram** — an interactive entity-relationship diagram of your Benchling configuration, with schema-lint visualization, search and navigation, and the Prompt Builder for creating SQL queries and AI starting points from selected schema elements.
+- **Git integration** — Building on the free tier's export-to-git capability, Pro adds git as a source: Kenfigure Tool (Import) pulls configuration YAML directly from a repository branch, and Kenfigure Diagram reads and writes to your repository — saving layouts, sub-layouts, and schema-lint suppressions to a branch of your choice.
+
+---
+
+## Validated Cloud
+
+Kenfigure supports Benchling **Validated Cloud**. For GxP-regulated teams, a versioned source of truth, reviewed changes, and an auditable promotion path aren't conveniences — they're expectations. Kenfigure gives Validated Cloud customers exactly that: configuration kept under version control, changes that can be reviewed before they're applied, and a disciplined promotion through your **Sandbox/Preview** environments to production using Benchling's own Configuration Migration tool.
+
+Validated Cloud is supported across all tiers above. Because Validated Cloud deployments vary, [contact us](mailto:info@go2.software) for a tailored quote.
+
+---
+
+## Multi-year: commit, prepay, save
+
+The standard subscription is billed **annually in advance**, and renews each year at the then-current price.
+
+If you'd rather lock in your cost, **commit to a 2- or 3-year term and prepay it in full up front**. In return you get:
+
+- a **discount** off the annual rate (10% for 2 years, 15% for 3 years), and
+- a **price locked for the full committed term** — no increases during the term.
+
+After the committed term, the subscription renews in 1-year periods at the then-current price unless either party gives notice of non-renewal. Multi-year terms and prepayment are set out on your order form.
+
+---
+
+## Billing, taxes, and currency
+
+Kenfigure Pro is sold and billed through **Paddle** (Paddle.com Market Ltd.), our Merchant of Record. Prices are shown in **U.S. dollars and are exclusive of any applicable sales tax or VAT**, which Paddle calculates and adds at checkout or on your invoice based on your location.
+
+You can pay by **Card** or **Invoice / purchase order** (paid by bank transfer on net terms).
+
+Annual subscriptions are billed in advance and renew automatically. Multi-year terms are paid in full up front.
+
+---
+
+## Prices subject to change
+
+The prices shown above are current list prices and **may change at any time before you subscribe**. The price you pay is set when you subscribe. If you commit and prepay a multi-year term, that price is **locked for the full committed term**; annual subscriptions renew at the then-current list price. A change to list prices does not affect a subscription during a committed, prepaid term. See the [Kenfigure Subscription Terms](subscription_terms.html).
+
+---
+
+## Refunds
+
+Kenfigure Pro subscriptions are non-refundable, except as expressly provided in the [Kenfigure Subscription Terms — §4, "Refunds and cancellations"](subscription_terms.html#refund-policy): namely a 30-day refund if Kenfigure cannot operate in your environment, and the limited warranty remedy. See the [Refund Policy](subscription_terms.html#refund-policy) for details.
+
+---
+
+## Have questions?
+
+See the **[FAQ](faq.html)** for answers on licensing, coverage, security, and more.
+
+---
+
+## How to buy
+
+Choose your tier and term and complete the **[order form](https://auth.kenfigure.com/order)**. We provision your company and primary user(s) once your order is placed — you don't have to wait for payment to clear to get started.
+
+For **Enterprise** or **Validated Cloud**, [request a quote](https://auth.kenfigure.com/order) for a tailored price.
+
+<style>
+.pricing-order-btn {
+  display: inline-block; margin: 1rem 0;
+  padding: 0.75rem 2rem; background: #27ae60; color: #fff;
+  border-radius: 4px; font-size: 1rem; font-weight: bold; text-decoration: none;
+}
+.pricing-order-btn:hover { background: #219a52; color: #fff; }
+</style>
+
+<a href="https://auth.kenfigure.com/order" class="pricing-order-btn">Order Kenfigure Pro →</a>
+
+
+---
+
+[Back to Kenfigure home](https://kenfigure.com)

--- a/docs/privacy_policy.md
+++ b/docs/privacy_policy.md
@@ -1,0 +1,62 @@
+---
+title: Kenfigure Privacy Policy
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Privacy Policy
+
+_Effective June 2026. Go2 Software LLC, 365 Boston Post Road, Suite 132, Sudbury, MA 01776, USA, [privacy@go2.software](mailto:privacy@go2.software). Kenfigure is a product of Go2 Software LLC._
+
+---
+
+## 1. Who we are and what this covers
+
+This policy explains how Go2 Software LLC ("Go2," "we") handles personal information across the kenfigure.com website, the free **Kenfigure Tool™ (Export)**, and the paid **Kenfigure Pro™** Service. Where we process personal data on your behalf (as a data processor), that handling is also governed by the [Data Processing Addendum](data_processing_addendum.html).
+
+## 2. Information we collect
+
+- **Contact and account information** you provide: name, business email, company, role, and Benchling tenant identifiers.
+- **Free-tier email:** when you use the free Export tool, we receive the email address associated with your use of it.
+- **Configuration data** you export, import, or diagram. This is configuration schema (the structure of a Benchling deployment), not scientific, research, clinical, or patient data.
+- **Usage and log data:** standard technical information such as access times, IP address, and basic diagnostics.
+- **Website cookies:** essential cookies for the site to function; any non-essential cookies are used only with your consent.
+
+## 3. How we use it
+
+To provide, secure, and support the Service; to provision accounts; to process payment and renewals through our payment provider; to communicate with you about your account and service-related matters; and to comply with legal obligations. Where we send optional product or marketing emails, we do so on the basis of your consent or an existing customer relationship, and you can opt out at any time.
+
+## 4. How we share it
+
+We share personal information only with service providers who help us run the Service, under appropriate confidentiality and data-protection terms. Our subprocessors include Amazon Web Services (hosting, including Amazon Bedrock for an AI feature), Paddle (Paddle.com Market Ltd.) for payment, and our transactional email providers (currently Fastmail Pty Ltd and Forward Email LLC). We do not sell personal information. We may disclose information where required by law or to protect our rights, and in connection with a merger, acquisition, or sale of assets.
+
+## 5. Use of AI
+
+An optional feature uses Amazon Bedrock to help lay out diagrams. Amazon Bedrock does not use this data to train models and does not retain it.
+
+An optional feature provides an interface into Benchling's AI chat capabilities.
+
+## 6. International transfers
+
+The Service is hosted in the United States. If you access it from outside the United States, your information will be transferred to and processed in the US. For personal data subject to EU/UK data-protection law, we rely on appropriate safeguards (such as Standard Contractual Clauses) as described in the [Data Processing Addendum](data_processing_addendum.html).
+
+## 7. Data retention
+
+We keep personal information for as long as needed to provide the Service and for a reasonable period afterward to meet legal, tax, and accounting requirements. Configuration data copies held by the Service are transient and are removed when a subscription ends.
+
+## 8. Security
+
+We maintain reasonable administrative, technical, and organizational safeguards designed to protect personal information, as summarized in our [Security & Data Handling Overview](security_data_handling.html).
+
+## 9. Your rights
+
+Depending on where you live, you may have rights to access, correct, delete, or export your personal information, or to object to or restrict certain processing. To exercise these rights, contact us at [privacy@go2.software](mailto:privacy@go2.software). Requests relating to data we process on your behalf are handled under the [Data Processing Addendum](data_processing_addendum.html).
+
+## 10. Children
+
+The Service is for business use and is not directed to children, and we do not knowingly collect information from children.
+
+## 11. Changes and contact
+
+We may update this policy and will post the revised version with a new effective date. Questions or requests: [privacy@go2.software](mailto:privacy@go2.software), or by mail to the address above.

--- a/docs/security_data_handling.md
+++ b/docs/security_data_handling.md
@@ -1,0 +1,65 @@
+---
+title: Kenfigure Security & Data Handling Overview
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Security & Data Handling Overview
+
+_Go2 Software LLC, 365 Boston Post Road, Suite 132, Sudbury, MA 01776, USA · [security@go2.software](mailto:security@go2.software). Kenfigure is a product of Go2 Software LLC. Last updated: June 2026._
+
+---
+
+**The short version.** **Kenfigure Pro™** and the free **Kenfigure Tool™ (Export)** help you manage your Benchling **configuration**. Both operate on configuration schema — the structure of your Benchling deployment — not your scientific, research, clinical, or patient data. Neither product accesses Benchling experimental, research, or sample data. Any configuration information held by the Service is a transient, read-only copy and is never the system of record.
+
+## What we process
+
+- **Configuration schema and related metadata:** schema and dropdown definitions and diagram layout information, used to provide export, import, and diagramming features.
+- **Limited account and contact information:** authorized users' names, business email addresses, company affiliation, role, and Benchling tenant identifiers.
+- **We do not** access, store, or process your Benchling scientific, research, sample, or patient data.
+
+## Hosting and infrastructure
+
+The Service runs on Amazon Web Services in the United States, in an account dedicated to Kenfigure. Infrastructure is deployed and maintained as code, backed by version control and standard code-quality tooling.
+
+## Access control
+
+Access to Go2 Software production systems is restricted to authorized Go2 Software personnel on a least-privilege basis. All administrative access requires multi-factor authentication.
+
+## Authentication
+
+Kenfigure Diagram users have individual accounts. Password complexity is enforced; users set their password on first login via a secure link, and subsequent resets are performed via a link sent to the user's registered email. Passwords are stored only as one-way hashes. The Kenfigure Tool (Canvas app) uses Benchling's own authentication — Go2 does not handle or store those credentials.
+
+## Encryption
+
+Data is encrypted in transit using TLS. Data at rest is encrypted using AWS-managed encryption.
+
+## Git repository access (optional)
+
+If you choose to use your own Git repository as a configuration source, you create a limited-scope access token that you control. The token is supplied through Benchling's native Canvas secure-configuration capability, which encrypts it with Kenfigure's public key before transmitting it. Kenfigure decrypts the token in memory using its private key solely to make Git API calls and never stores it in plain text. You set the token's scope and duration and can revoke it at any time. We recommend the most fine-grained token type each provider offers. GitHub, GitLab, and Bitbucket are supported.
+
+## Use of AI
+
+An optional grouping feature uses Amazon Bedrock to cluster schema elements for diagram layout (currently using Anthropic models). Amazon Bedrock does not use this data to train models and does not retain it.
+
+## Subprocessors
+
+- **Amazon Web Services** (hosting, including Amazon Bedrock for the AI grouping feature)
+- **Paddle** (Paddle.com Market Ltd. — payment processing and billing; Merchant of Record / seller of record)
+- **Fastmail Pty Ltd** (go2.software transactional and order-processing email)
+- **Forward Email LLC** (kenfigure.com account and password-reset emails)
+
+A current subprocessor list is available in the [Data Processing Addendum](data_processing_addendum.html).
+
+## Changes to configuration
+
+Kenfigure Tool™ (Import) generates a Benchling Configuration Migration file. You review and apply changes using Benchling's own Configuration Migration tool — Kenfigure does not push changes to your Benchling environments. Recommended practice is to import to a non-production (Dev/Test, or Sandbox/Preview) tenant first, validate, and then promote to production using Benchling's tool.
+
+## Data retention and deletion
+
+Configuration copies held by the Service are transient. When a subscription ends, account access is closed and configuration data is removed. Limited account records may be retained as needed for legal and financial purposes, as described in the [Privacy Policy](privacy_policy.html).
+
+## Questions
+
+Security and data-handling questions: [security@go2.software](mailto:security@go2.software).

--- a/docs/subscription_terms.md
+++ b/docs/subscription_terms.md
@@ -1,0 +1,80 @@
+---
+title: Kenfigure Pro™ Subscription Terms
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Pro™ Subscription Terms
+
+_Effective June 2026. Go2 Software LLC, 365 Boston Post Road, Suite 132, Sudbury, MA 01776, USA, [info@go2.software](mailto:info@go2.software). Kenfigure is a product of Go2 Software LLC._
+
+---
+
+## 1. Agreement and acceptance
+
+These Kenfigure Subscription Terms (the "**Terms**") govern access to and use of the paid **Kenfigure Pro™** service (the "**Service**") provided by Go2 Software LLC ("**Provider**," "we," "us") to the customer identified on the applicable order form ("**Customer**," "you"). Each order form that references these Terms (an "**Order Form**"), together with these Terms and any addenda incorporated by reference (including the [Privacy Policy](privacy_policy.html) and [Data Processing Addendum](data_processing_addendum.html)), forms the "**Agreement**."
+
+By signing or otherwise accepting an Order Form, or by accessing or using the Service, Customer agrees to the Agreement. For Standard and Growth tiers the Agreement is offered on a click-accept basis and is not negotiated; Enterprise and Validated Cloud orders may be individually negotiated. If the person accepting is doing so on behalf of an entity, they represent that they are authorized to bind that entity.
+
+The free **Kenfigure Tool™ (Export)** is not part of the Service and is governed separately by the [Kenfigure Free-Tier Terms](free_tier_terms.html).
+
+## 2. The Service and license
+
+Subject to the Agreement and payment of fees, Provider grants Customer a non-exclusive, non-transferable, non-sublicensable right, during the subscription term, to access and use the Service for Customer's internal business purposes of managing Customer's Benchling configuration. The license covers all of Customer's Benchling environments (e.g., Dev, Test, Prod, and any Sandbox/Preview tenants). The object types and features supported by each Service component are described in the then-current [Kenfigure Feature Support Matrix](feature_matrix.html) on Provider's website. Provider provisions Customer's account and an initial administrator user for Kenfigure Diagram; additional Kenfigure Diagram users may be added by Provider upon Customer's request. The Kenfigure Tool (Canvas app) is accessed through Customer's Benchling environment and requires no separate provisioning; Customer's Benchling administrator controls which Benchling users may access it.
+
+Customer will not, and will not permit others to: (a) resell, sublicense, or provide the Service to third parties except as expressly permitted; (b) reverse engineer or attempt to derive source code, except to the extent that restriction is prohibited by law; (c) use the Service to build a competing product; or (d) remove proprietary notices.
+
+## 3. Customer responsibilities and recommended use
+
+Customer is responsible for: (a) providing accurate provisioning and contact information; (b) safeguarding its credentials and any access tokens (including any Git access token, which is supplied and secured through Benchling's native Canvas capabilities); (c) its users' compliance with the Agreement; and (d) maintaining its own agreements with, and complying with the terms of, Benchling and any third-party code repository it connects.
+
+**Reviewing changes.** Kenfigure Tool (Import) generates a Benchling Configuration Migration file. To apply changes, Customer uploads that file to Benchling's Configuration Migration tool, which presents a review UI showing the changes that will occur before Customer confirms the import. Customer is solely responsible for reviewing those changes in Benchling's tool and for deciding whether to proceed. Provider does not itself apply changes to Customer's Benchling environments.
+
+**Recommended practice.** Provider strongly recommends importing only to a non-production (Dev/Test, or Sandbox/Preview) tenant first, validating the result there, and then promoting the configuration to production using Benchling's Configuration Migration tool. **Customers should not import directly to a production tenant.** Customer acknowledges that it controls and is responsible for changes made to its production environments.
+
+## 4. Fees, payment, and refunds {#refund-policy}
+
+Fees are stated on the Order Form and billed annually in advance through Provider's payment provider (Merchant of Record), by card, ACH, or invoice/PO as offered. The Merchant of Record is the seller of record for the transaction and handles applicable taxes; fees are otherwise exclusive of taxes that are Customer's responsibility. Fees for a committed term are fixed (price-locked) as stated on the Order Form. Undisputed late amounts may accrue interest at the lower of 1% per month or the maximum allowed by law, and Provider may suspend the Service for non-payment after reasonable notice.
+
+**Refunds and cancellations.** Except as expressly stated in this Section 4, fees are non-refundable, and there are no refunds for unused or partial subscription periods, including after cancellation. To decline renewal and stop future billing, Customer gives written notice of non-renewal as stated on the Order Form and in Section 11; cancellation takes effect at the end of the then-current term and does not refund fees already paid for that term. Refunds of prepaid, unused fees are available only: (a) if, within 30 days of the start date, the Service cannot be made to work in Customer's environment and the incompatibility cannot reasonably be remedied (Section 11); or (b) under the warranty remedy in Section 8. Where a refund is due, it is issued through the Merchant of Record to the original payment method, and the amount may differ slightly from the amount paid due to tax or currency-exchange recalculation. Nothing in this Section limits Customer's rights regarding a Service that is not as described, faulty, or not fit for purpose. _(This Section is the "Refund Policy" referenced on Provider's website.)_
+
+## 5. Customer Data and security
+
+"**Customer Data**" means the configuration data, files, and other content Customer provides to or generates through the Service, plus Customer's account and contact information. As between the parties, Customer owns Customer Data. Customer grants Provider a limited license to host, process, and use Customer Data solely to provide and support the Service.
+
+Provider processes primarily configuration schema (structure, not scientific, research, clinical, or patient data) and limited contact information. The Service is hosted on Amazon Web Services, and certain features (e.g., diagram layout assistance) use Amazon Bedrock within Provider's own infrastructure. Provider will maintain reasonable administrative, technical, and organizational safeguards designed to protect Customer Data. Provider's processing of any personal data, and its subprocessors, are described in the [Privacy Policy](privacy_policy.html) and [Data Processing Addendum](data_processing_addendum.html), which are incorporated by reference.
+
+## 6. Intellectual property
+
+Provider owns and retains all right, title, and interest in the Service and all related software, documentation, and IP. The open Kenfigure standard published by Provider is licensed separately under its own open-source license and is not restricted by this Agreement. If Customer provides feedback or suggestions, Provider may use them without restriction or obligation.
+
+## 7. Confidentiality
+
+Each party may receive the other's non-public information ("**Confidential Information**"). The receiving party will use it only to perform under the Agreement, protect it with at least reasonable care, and not disclose it except to those who need it and are bound by similar obligations. This does not apply to information that is public, independently developed, or rightfully received from a third party, or to disclosures required by law (with notice where permitted).
+
+## 8. Warranty and disclaimer
+
+Provider warrants that during the subscription term the Service will perform materially in accordance with its then-current documentation. Customer's exclusive remedy, and Provider's sole obligation, for breach of this warranty is for Provider to use reasonable efforts to correct the non-conformity or, failing that within a reasonable time, to terminate the affected subscription and refund any prepaid, unused fees for the terminated period.
+
+**Except for the express warranty above, the Service and all outputs are provided "AS IS."** Provider disclaims all other warranties, express or implied, including merchantability, fitness for a particular purpose, and non-infringement. Provider does not warrant that the Service or any generated Configuration Migration file will be error-free or that importing a file will not affect Customer's Benchling environments; Customer is responsible for reviewing outputs and following the recommended practice in Section 3.
+
+## 9. Limitation of liability
+
+To the maximum extent permitted by law: (a) neither party will be liable for indirect, incidental, special, consequential, or punitive damages, or for lost profits, lost revenue, business interruption, or loss or corruption of data, even if advised of the possibility; and (b) each party's total aggregate liability arising out of or related to the Agreement will not exceed **one million U.S. dollars ($1,000,000)**. The limitations in this Section do not apply to Customer's obligation to pay fees due.
+
+## 10. Indemnification
+
+Provider will defend Customer against third-party claims alleging that the Service, as provided and used in accordance with the Agreement, infringes that third party's intellectual property rights, and will pay resulting damages finally awarded or agreed in settlement. This does not apply to claims arising from Customer Data, Customer's modifications, use of the Service in violation of the Agreement, or combination with non-Provider products. If the Service is or may be enjoined, Provider may modify it, obtain a license, or terminate the affected subscription and refund prepaid, unused fees.
+
+Customer will defend Provider against third-party claims arising from Customer Data, Customer's use of the Service in violation of the Agreement, or Customer's breach of its agreements with Benchling or its code repository, and will pay resulting damages finally awarded or agreed.
+
+The party seeking indemnity will give prompt notice, reasonable cooperation, and control of the defense (no settlement imposing obligations on the indemnified party without consent).
+
+## 11. Term, termination, and suspension
+
+The subscription term and renewal are stated on the Order Form. Unless the Order Form states a specific renewal price, renewals are at Provider's then-current pricing for the applicable tier; the committed-term price lock in Section 4 applies during the committed term only and does not carry into renewal terms. Either party may terminate for the other's material breach not cured within 30 days of written notice, or immediately if the other becomes insolvent. **Environment compatibility:** if within 30 days of the start date the Service cannot be made to work in Customer's environment and the incompatibility cannot reasonably be remedied, either party may terminate and Provider will refund prepaid, unused fees. On termination, Customer's access ends; Sections that by their nature should survive (including 5–10 and 12) survive. Provider may suspend the Service for non-payment, security risk, or legal requirement, with notice where practicable.
+
+## 12. General
+
+The Agreement is governed by the laws of the Commonwealth of Massachusetts, USA, without regard to conflict-of-laws rules, and the parties submit to the exclusive jurisdiction of the state and federal courts located in Massachusetts. Provider may update the Service and these Terms; for any material adverse change Provider will give reasonable notice, and committed-term pricing and terms on an existing Order Form remain locked for that term. Neither party may assign the Agreement without the other's consent, except that either party may assign it to a successor in a merger, acquisition, or sale of substantially all assets. Neither party is liable for delays caused by events beyond its reasonable control. Notices will be in writing to the addresses on the Order Form.


### PR DESCRIPTION
Adds pricing, FAQ, feature matrix, privacy policy, subscription terms,
   DPA, free-tier terms, and security overview. Updates footer with full
   nav links and trademark text; adds security_email to _config.yml.