### PR TITLE
Revamp-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ builds on the open standard to close the loop from source of truth back to Bench
 - **Computed and snapshot fields** — create and inspect computed fields without requiring Benchling support
 - **Drift detection and correction** — detect and reconcile drift between your YAML and the live Benchling state
 - **Notify directive** — embed manual instructions (e.g., configure a dashboard, set permissions) as part of an import sequence
-- **Feature flag control** — apply feature flag settings from YAML alongside all other configuration changes
 - **Prompt Builder** — assemble targeted schema context for SQL development or AI tools from Kenfigure Diagram
 
 → [Learn more about Kenfigure Pro™](kenfigure_pro.html)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ of your Benchling tenant configurations.
 Because it is a structured human *and* machine readable format, it works exceptionally well with git
 and can therefore form the foundation of a top-notch change management process.
 
-*Kenfigure* is highly useful solely as a standalone documentation tool,
-but I also use it for internal tools I've developed
-to programmatically deploy configurations, extract and document configurations,
-check against a set of schema quality rules and create dynamic ER diagrams.
-I created the spec for my internal tool use, but am making it publicly available since it
-is highly valuable as a way to document the source-of-truth for Benchling configurations
-even without leveraging any tools.
+*Kenfigure* is highly useful as a standalone documentation and source-of-truth tool — valuable on
+its own, independent of any additional tooling. Go2 Software also builds
+[**Kenfigure Pro™**](kenfigure_pro.html) on the standard: a commercial
+suite (Kenfigure Tool™ and Kenfigure Diagram™) for programmatic configuration export and import,
+schema quality checking, and interactive ER diagrams. The spec is openly published and independently
+useful whether or not you use those tools.
 
 Here's a very stripped down example:
 ```yaml
@@ -52,60 +51,64 @@ Entity_schemas:
 See [examples/Chemical.yaml](./examples/Chemical.yaml) for a more complete annotated example.
 
 # Documentation and essential references
-- [Kenfigure documentation](./annotated.md) - This is the primary documentation in the form of annotated examples.
-- [Complete schema reference](./reference.md) - This is not as user friendly, but it is comprehensive.
-- [Schema design style guide](./schema_design_style_guide.md) - This is an
-  opinionated guide related to style aspects of schema design in Benchling.
-  This is a companion to Kenfigure but is independent of the Kenfigure specification.
-  Some custom tooling (e.g., Kenfigure Tool Schema Lint) may use the style guide as a source for style rules.
-- [Kenfigure Tool User Guide](./kenfigure_tool_user_guide.md) - A Benchling App Canvas application that converts between Benchling and Kenfigure formats. Includes Git integration.
+- [Kenfigure documentation](./annotated.md) - Primary documentation in the form of annotated examples.
+- [Complete schema reference](./reference.md) - Comprehensive but dense; the annotated docs are more approachable.
+- [Schema design style guide](./schema_design_style_guide.md) - Opinionated style guidance for Benchling schema design.
+  A companion to Kenfigure but independent of the specification.
+  Kenfigure Tool Schema Lint uses the style guide as a source for quality rules.
+- [Kenfigure Tool User Guide](./kenfigure_tool_user_guide.md) - Guide for the Benchling Canvas app (Export/Import, Git integration).
 - [Kenfigure JSON schema](./jsonschemas/latest/kenfigure.schema_flat.json) - The full (flattened) JSON schema for Kenfigure.
 - [Kenfigure on GitHub](https://github.com/kennovation1/kenfigure) - Open-source schema repository, issues, and contributions.
+- [Kenfigure Pro™](kenfigure_pro.html) - The commercial tool suite built on this standard (Kenfigure Tool Import, Kenfigure Diagram).
 
-# Benefits 
-Here are some benefits of documenting your Benchling configuration in *kenfigure* files in git. In no particular order:
-(Note that I'm included some benefits are required additional tooling that is not open source.
-I've left these bullet points here since it helps to show the future possibilities whether it's with Go2 Software
-proprietary tools or others.)
-- Allows comments, notes, annotations on schemas and schema fields
+# Benefits
+
+## What the open standard gives you
+
+Here are the benefits of documenting your Benchling configuration as *Kenfigure* YAML files in git.
+These require only the open standard — no commercial tooling:
+
+- Comments, notes, and annotations on schemas and schema fields
 - Version control including branching and pull requests
-- Version difference inspection
-- Reusable/shareable components and patterns
+- Version difference inspection — diff any two configurations or environment states
+- Reusable and shareable components and patterns
 - Templatized components and patterns
-- Faster configuration (no UI clicking) [using additional tooling]
-- Fewer errors
-- Consistency between environments
-- Configuration rollback [using additional tooling]
-- Can integrate with visualization tools [e.g., I have a tool to create ER diagrams from the *kenfigure* specification]
-  - Support hints for automated diagram layout generation
-- Enables the ability to write model checkers and style checkers [e.g., I have a tool, "SchemaLint", that checks for many issues and anti-patters that I seen over the years]
-  - No more fields with hidden leading or trialing spaces!
-- Allows for more complete, verifiable, and easier configurations review (particular useful for validated environments)
-- Documentation for validated environments
-- Enables global spell checking
-- Enables global search to find configuration information, verify settings, check for consistency, check for conflicts, etc.
-- Easy global search and replace
-- Basic tools like grep (and grep -R) can make it very easy to see things like "all prefixes" or "all names" or all
-  schemas that refer to a given entity.
-- IDE support for hover hints and typing completion
-- GitHub Copilot typing completions
-- Can implement special operations (e.g., to help migrations) such as bulk disable/enable require fields on entity schemas. [using additional tooling]
-- Copy & paste of common sections (e.g., fields)
-- Can try multiple model configurations
-- Edit, review, share, revise, all before committing to Benchling
-- There are lots of features of VSCode and DbSchema that are now possible. May are not listed here. Some thoughts...
-  - VSCode allows section expand/collapse, navigation crumbs, great when fleshing out multiple similar fields (lipid A, B, C...)
-  - DbSchema has various navigation and pan/zoom features. Cool to create layout from group
-  - YAML supports grouping which can drive DbSchema and in the future I may use this for filters and such
-  - Create layout from group is powerful
-- Create and inspect computed fields without requiring Benchling support [using additional tooling]
-- Detects and corrects drift [using additional tooling]
-- Supports Notify directive for manual instructions for imports (e.g., configure dashboard, set permissions) [using additional tooling]
-- Tracks feature flag settings and can convert to/from a CSV that Benchling support provides and can use to as a guide to perform updates
-  by filtering on "Planned Value" fields. By keeping feature flags in YAML it's easy to manage config changes with git and also
-  to see differences between tenants or versions (since diffs of sorted yamls is easier than diffs of Benchling xlsx files). This also
-  makes it possible to control feature flags along with all other configs. [using additional tooling]
-- Git management of YAMLs allows for hierarchical grouping of schemas in a folder tree
+- Fewer errors — YAML is reviewed before being applied, and IDE schema validation catches mistakes early
+- Consistency across environments — a single reviewed source of truth shared by Dev, Test, and Prod
+- More complete, verifiable, and auditable configuration reviews (particularly useful for validated environments)
+- Documentation suitable for validated environments
+- Global spell checking (IDE or editor spell checker runs across all YAML files)
+- Global search — find all uses of a field name, check for consistency, detect conflicts, see all prefixes at once
+- Easy global search and replace across the entire configuration
+- Quick grep queries: `grep -R "prefix:" .` lists every schema prefix in one command
+- IDE support for hover hints and typing completion (see VS Code / Cursor setup below)
+- GitHub Copilot and other AI assistant completions — especially effective when the full configuration is in context
+- Copy and paste of common sections (e.g., standard field groups)
+- Draft and iterate on multiple model configurations before committing anything to Benchling
+- Edit, review, share, and revise collaboratively before any change touches Benchling
+- VSCode-specific benefits: section expand/collapse, navigation breadcrumbs, great for building out multiple similar fields
+- YAML folder-tree grouping allows hierarchical organization of schemas in a directory structure
+- Track feature flag settings as YAML — diff tenants or versions far more easily than comparing Benchling's xlsx export files
+
+## What Kenfigure Pro adds
+
+[**Kenfigure Pro™**](kenfigure_pro.html) (Kenfigure Tool™ and Kenfigure Diagram™)
+builds on the open standard to close the loop from source of truth back to Benchling:
+
+- **Faster, accurate configuration import** — push changes back to Benchling directly from YAML; no manual UI clicking
+- **Configuration rollback** — roll back to any previously versioned state and import it
+- **Interactive ER diagrams** — Kenfigure Diagram renders your schema as an explorable, searchable entity-relationship diagram
+  - Diagram layout hints in the YAML drive automatic grouping
+- **Schema lint with visual indicators** — Kenfigure Tool Schema Lint flags anti-patterns and style issues; Kenfigure Diagram surfaces them inline with suppression tracking
+  - No more fields with hidden leading or trailing spaces, inconsistent naming, or other common issues
+- **Bulk operations** — bulk enable/disable required fields on entity schemas and similar special operations
+- **Computed and snapshot fields** — create and inspect computed fields without requiring Benchling support
+- **Drift detection and correction** — detect and reconcile drift between your YAML and the live Benchling state
+- **Notify directive** — embed manual instructions (e.g., configure a dashboard, set permissions) as part of an import sequence
+- **Feature flag control** — apply feature flag settings from YAML alongside all other configuration changes
+- **Prompt Builder** — assemble targeted schema context for SQL development or AI tools from Kenfigure Diagram
+
+→ [Learn more about Kenfigure Pro™](kenfigure_pro.html)
 
 # Mindset
 - Generally the key names in the specification match or closely match the terminology Benchling uses in the UI.
@@ -174,5 +177,6 @@ Here's some doc for how to configure [PyCharm for YAML editing with a custom sch
 
 You are free to use, adapt, and share this schema with proper attribution.
 
-Commercial use of software tools that rely on this schema may require a separate license.  
-Please contact [info@go2software.com](mailto:info@go2software.com) for commercial licensing inquiries.
+Commercial use of software tools that rely on this schema may require a separate license.
+See [Kenfigure Pro™](kenfigure_pro.html) for Go2 Software's commercial tool suite,
+or contact [info@go2.software](mailto:info@go2.software) with questions.

--- a/docs/_includes/site-footer.html
+++ b/docs/_includes/site-footer.html
@@ -3,6 +3,7 @@
 
   <nav class="site-footer__nav" aria-label="Legal and policies">
     <ul>
+      <li><a href="{{ '/kenfigure_pro.html' | relative_url }}">Kenfigure Pro</a></li>
       <li><a href="{{ '/pricing.html' | relative_url }}">Pricing</a></li>
       <li><a href="{{ '/faq.html' | relative_url }}">FAQ</a></li>
       <li><a href="{{ '/feature_matrix.html' | relative_url }}">Feature Support Matrix</a></li>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,6 +9,8 @@ layout: default
 
 _Go2 Software LLC · [info@go2.software](mailto:info@go2.software)_
 
+_Not sure what Kenfigure Pro is? [Read the product overview](kenfigure_pro.html) first._
+
 ---
 
 ## Getting started

--- a/docs/feature_enablement.md
+++ b/docs/feature_enablement.md
@@ -2,21 +2,20 @@
 
 # Enable Kenfigure Features
 
-This page describes the premium features available for Kenfigure Tool and Kenfigure Diagram and how to get them enabled for your tenant.
+This page describes the **Kenfigure Pro™** features available for Kenfigure Tool and Kenfigure Diagram and how to get them enabled for your tenant.
 
 If you arrived here from a disabled button or link in the Kenfigure Tool canvas, you're in the right place.
 
 Kenfigure Tool provides the ability to export your Benchling configuration into Kenfigure
-format either as a .zip file or directly to your git repository.
+format either as a .zip file or directly to your git repository — free for all users.
 
-Importing back to Benchling and the use of the powerful Kenfigure Diagram application
-are part of the premium upgrade to Kenfigure Tool.
-Please ask your Benchling administrator to contact us about upgrading to the premium
-version of Kenfigure Tool. 
+Importing back to Benchling and the use of Kenfigure Diagram are part of
+**[Kenfigure Pro™](kenfigure_pro.html)**.
+Please ask your Benchling administrator to contact us about subscribing to Kenfigure Pro.
 
 ---
 
-## Available Features in the upgrade
+## What Kenfigure Pro includes
 
 ### Import to Benchling (Canvas Import)
 
@@ -60,7 +59,7 @@ git Kenfigure specification.
 
 ## How to Enable
 
-**To request access:**, email [info@go2.software](mailto:info@go2.software)
+Email [info@go2.software](mailto:info@go2.software) to subscribe to Kenfigure Pro or to request access for your tenant.
 
 ---
 
@@ -86,8 +85,8 @@ No. Feature enablement is handled server-side and takes effect immediately witho
 
 ## Pricing
 
-Contact [info@go2.software](mailto:info@go2.software) 
+See the **[Kenfigure Pricing page](pricing.html)** for current subscription tiers and pricing, or the **[Kenfigure Pro overview](kenfigure_pro.html)** for a full description of what's included. For Enterprise or Validated Cloud inquiries, contact [info@go2.software](mailto:info@go2.software).
 
 ---
 
-[Back to Kenfigure home](https://kenfigure.com) · [User Guide](https://kenfigure.com/kenfigure_tool_user_guide.html)
+[Back to Kenfigure home](https://kenfigure.com) · [User Guide](kenfigure_tool_user_guide.html)

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -55,4 +55,8 @@ Top-level Kenfigure object types from the [Kenfigure JSON schema](https://kenfig
 
 ---
 
+Interested in adding Export, Import, or Diagram to your team? See [Kenfigure Pro™](kenfigure_pro.html) or the [Pricing page](pricing.html).
+
+---
+
 [Back to Kenfigure home](https://kenfigure.com)

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,6 @@ builds on the open standard to close the loop from source of truth back to Bench
 - **Computed and snapshot fields** — create and inspect computed fields without requiring Benchling support
 - **Drift detection and correction** — detect and reconcile drift between your YAML and the live Benchling state
 - **Notify directive** — embed manual instructions (e.g., configure a dashboard, set permissions) as part of an import sequence
-- **Feature flag control** — apply feature flag settings from YAML alongside all other configuration changes
 - **Prompt Builder** — assemble targeted schema context for SQL development or AI tools from Kenfigure Diagram
 
 → [Learn more about Kenfigure Pro™](kenfigure_pro.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,13 +11,12 @@ of your Benchling tenant configurations.
 Because it is a structured human *and* machine readable format, it works exceptionally well with git
 and can therefore form the foundation of a top-notch change management process.
 
-*Kenfigure* is highly useful solely as a standalone documentation tool,
-but I also use it for internal tools I've developed
-to programmatically deploy configurations, extract and document configurations,
-check against a set of schema quality rules and create dynamic ER diagrams.
-I created the spec for my internal tool use, but am making it publicly available since it
-is highly valuable as a way to document the source-of-truth for Benchling configurations
-even without leveraging any tools.
+*Kenfigure* is highly useful as a standalone documentation and source-of-truth tool — valuable on
+its own, independent of any additional tooling. Go2 Software also builds
+[**Kenfigure Pro™**](kenfigure_pro.html) on the standard: a commercial
+suite (Kenfigure Tool™ and Kenfigure Diagram™) for programmatic configuration export and import,
+schema quality checking, and interactive ER diagrams. The spec is openly published and independently
+useful whether or not you use those tools.
 
 Here's a very stripped down example:
 ```yaml
@@ -52,60 +51,64 @@ Entity_schemas:
 See [examples/Chemical.yaml](./examples/Chemical.yaml) for a more complete annotated example.
 
 # Documentation and essential references
-- [Kenfigure documentation](./annotated.md) - This is the primary documentation in the form of annotated examples.
-- [Complete schema reference](./reference.md) - This is not as user friendly, but it is comprehensive.
-- [Schema design style guide](./schema_design_style_guide.md) - This is an
-  opinionated guide related to style aspects of schema design in Benchling.
-  This is a companion to Kenfigure but is independent of the Kenfigure specification.
-  Some custom tooling (e.g., Kenfigure Tool Schema Lint) may use the style guide as a source for style rules.
-- [Kenfigure Tool User Guide](./kenfigure_tool_user_guide.md) - A Benchling App Canvas application that converts between Benchling and Kenfigure formats. Includes Git integration.
+- [Kenfigure documentation](./annotated.md) - Primary documentation in the form of annotated examples.
+- [Complete schema reference](./reference.md) - Comprehensive but dense; the annotated docs are more approachable.
+- [Schema design style guide](./schema_design_style_guide.md) - Opinionated style guidance for Benchling schema design.
+  A companion to Kenfigure but independent of the specification.
+  Kenfigure Tool Schema Lint uses the style guide as a source for quality rules.
+- [Kenfigure Tool User Guide](./kenfigure_tool_user_guide.md) - Guide for the Benchling Canvas app (Export/Import, Git integration).
 - [Kenfigure JSON schema](./jsonschemas/latest/kenfigure.schema_flat.json) - The full (flattened) JSON schema for Kenfigure.
 - [Kenfigure on GitHub](https://github.com/kennovation1/kenfigure) - Open-source schema repository, issues, and contributions.
+- [Kenfigure Pro™](kenfigure_pro.html) - The commercial tool suite built on this standard (Kenfigure Tool Import, Kenfigure Diagram).
 
-# Benefits 
-Here are some benefits of documenting your Benchling configuration in *kenfigure* files in git. In no particular order:
-(Note that I'm included some benefits are required additional tooling that is not open source.
-I've left these bullet points here since it helps to show the future possibilities whether it's with Go2 Software
-proprietary tools or others.)
-- Allows comments, notes, annotations on schemas and schema fields
+# Benefits
+
+## What the open standard gives you
+
+Here are the benefits of documenting your Benchling configuration as *Kenfigure* YAML files in git.
+These require only the open standard — no commercial tooling:
+
+- Comments, notes, and annotations on schemas and schema fields
 - Version control including branching and pull requests
-- Version difference inspection
-- Reusable/shareable components and patterns
+- Version difference inspection — diff any two configurations or environment states
+- Reusable and shareable components and patterns
 - Templatized components and patterns
-- Faster configuration (no UI clicking) [using additional tooling]
-- Fewer errors
-- Consistency between environments
-- Configuration rollback [using additional tooling]
-- Can integrate with visualization tools [e.g., I have a tool to create ER diagrams from the *kenfigure* specification]
-  - Support hints for automated diagram layout generation
-- Enables the ability to write model checkers and style checkers [e.g., I have a tool, "SchemaLint", that checks for many issues and anti-patters that I seen over the years]
-  - No more fields with hidden leading or trialing spaces!
-- Allows for more complete, verifiable, and easier configurations review (particular useful for validated environments)
-- Documentation for validated environments
-- Enables global spell checking
-- Enables global search to find configuration information, verify settings, check for consistency, check for conflicts, etc.
-- Easy global search and replace
-- Basic tools like grep (and grep -R) can make it very easy to see things like "all prefixes" or "all names" or all
-  schemas that refer to a given entity.
-- IDE support for hover hints and typing completion
-- GitHub Copilot typing completions
-- Can implement special operations (e.g., to help migrations) such as bulk disable/enable require fields on entity schemas. [using additional tooling]
-- Copy & paste of common sections (e.g., fields)
-- Can try multiple model configurations
-- Edit, review, share, revise, all before committing to Benchling
-- There are lots of features of VSCode and DbSchema that are now possible. May are not listed here. Some thoughts...
-  - VSCode allows section expand/collapse, navigation crumbs, great when fleshing out multiple similar fields (lipid A, B, C...)
-  - DbSchema has various navigation and pan/zoom features. Cool to create layout from group
-  - YAML supports grouping which can drive DbSchema and in the future I may use this for filters and such
-  - Create layout from group is powerful
-- Create and inspect computed fields without requiring Benchling support [using additional tooling]
-- Detects and corrects drift [using additional tooling]
-- Supports Notify directive for manual instructions for imports (e.g., configure dashboard, set permissions) [using additional tooling]
-- Tracks feature flag settings and can convert to/from a CSV that Benchling support provides and can use to as a guide to perform updates
-  by filtering on "Planned Value" fields. By keeping feature flags in YAML it's easy to manage config changes with git and also
-  to see differences between tenants or versions (since diffs of sorted yamls is easier than diffs of Benchling xlsx files). This also
-  makes it possible to control feature flags along with all other configs. [using additional tooling]
-- Git management of YAMLs allows for hierarchical grouping of schemas in a folder tree
+- Fewer errors — YAML is reviewed before being applied, and IDE schema validation catches mistakes early
+- Consistency across environments — a single reviewed source of truth shared by Dev, Test, and Prod
+- More complete, verifiable, and auditable configuration reviews (particularly useful for validated environments)
+- Documentation suitable for validated environments
+- Global spell checking (IDE or editor spell checker runs across all YAML files)
+- Global search — find all uses of a field name, check for consistency, detect conflicts, see all prefixes at once
+- Easy global search and replace across the entire configuration
+- Quick grep queries: `grep -R "prefix:" .` lists every schema prefix in one command
+- IDE support for hover hints and typing completion (see VS Code / Cursor setup below)
+- GitHub Copilot and other AI assistant completions — especially effective when the full configuration is in context
+- Copy and paste of common sections (e.g., standard field groups)
+- Draft and iterate on multiple model configurations before committing anything to Benchling
+- Edit, review, share, and revise collaboratively before any change touches Benchling
+- VSCode-specific benefits: section expand/collapse, navigation breadcrumbs, great for building out multiple similar fields
+- YAML folder-tree grouping allows hierarchical organization of schemas in a directory structure
+- Track feature flag settings as YAML — diff tenants or versions far more easily than comparing Benchling's xlsx export files
+
+## What Kenfigure Pro adds
+
+[**Kenfigure Pro™**](kenfigure_pro.html) (Kenfigure Tool™ and Kenfigure Diagram™)
+builds on the open standard to close the loop from source of truth back to Benchling:
+
+- **Faster, accurate configuration import** — push changes back to Benchling directly from YAML; no manual UI clicking
+- **Configuration rollback** — roll back to any previously versioned state and import it
+- **Interactive ER diagrams** — Kenfigure Diagram renders your schema as an explorable, searchable entity-relationship diagram
+  - Diagram layout hints in the YAML drive automatic grouping
+- **Schema lint with visual indicators** — Kenfigure Tool Schema Lint flags anti-patterns and style issues; Kenfigure Diagram surfaces them inline with suppression tracking
+  - No more fields with hidden leading or trailing spaces, inconsistent naming, or other common issues
+- **Bulk operations** — bulk enable/disable required fields on entity schemas and similar special operations
+- **Computed and snapshot fields** — create and inspect computed fields without requiring Benchling support
+- **Drift detection and correction** — detect and reconcile drift between your YAML and the live Benchling state
+- **Notify directive** — embed manual instructions (e.g., configure a dashboard, set permissions) as part of an import sequence
+- **Feature flag control** — apply feature flag settings from YAML alongside all other configuration changes
+- **Prompt Builder** — assemble targeted schema context for SQL development or AI tools from Kenfigure Diagram
+
+→ [Learn more about Kenfigure Pro™](kenfigure_pro.html)
 
 # Mindset
 - Generally the key names in the specification match or closely match the terminology Benchling uses in the UI.
@@ -174,5 +177,6 @@ Here's some doc for how to configure [PyCharm for YAML editing with a custom sch
 
 You are free to use, adapt, and share this schema with proper attribution.
 
-Commercial use of software tools that rely on this schema may require a separate license.  
-Please contact [info@go2software.com](mailto:info@go2software.com) for commercial licensing inquiries.
+Commercial use of software tools that rely on this schema may require a separate license.
+See [Kenfigure Pro™](kenfigure_pro.html) for Go2 Software's commercial tool suite,
+or contact [info@go2.software](mailto:info@go2.software) with questions.

--- a/docs/kenfigure_pro.md
+++ b/docs/kenfigure_pro.md
@@ -1,0 +1,103 @@
+---
+title: Kenfigure Pro
+layout: default
+---
+
+[Kenfigure home](https://kenfigure.com)
+
+# Kenfigure Pro™
+
+_Kenfigure is a product of Go2 Software LLC · Last updated: June 2026_
+
+<style>
+.kf-cta-btn {
+  display: inline-block; margin: 1rem 0;
+  padding: 0.75rem 2rem; background: #27ae60; color: #fff;
+  border-radius: 4px; font-size: 1rem; font-weight: bold; text-decoration: none;
+}
+.kf-cta-btn:hover { background: #219a52; color: #fff; }
+</style>
+
+The configuration-management discipline software teams apply to code — now for your Benchling platform.
+
+<a href="pricing.html" class="kf-cta-btn">See pricing →</a>  &nbsp; [Read the FAQ](faq.html)
+
+---
+
+## The problem with Benchling configuration management
+
+Benchling configuration — entity schemas, dropdowns, result schemas, templates, and more — is complex, evolves constantly, and exists only as UI clicks. There is no version history, no way to propose and review a change before it is applied, no easy path to reproduce a configuration in a new environment, and no visual overview of how everything fits together.
+
+For small teams at an early stage this is manageable. For growing teams, for cross-environment consistency, and especially for regulated environments, configuration debt accumulates fast.
+
+---
+
+## The foundation is free and open
+
+Kenfigure starts with a structured, version-controlled source of truth.
+
+The **[Kenfigure™ YAML standard](https://kenfigure.com)** is open-source: a documented format for describing Benchling configurations as human- and machine-readable text. It maps directly to what you see in the Benchling UI, works naturally with Git (branches, pull requests, diffs, code review), and integrates with modern IDEs for completions, hints, and schema validation.
+
+**Kenfigure Tool™ (Export)** is free for all Benchling users. It runs as a Benchling Canvas app and exports your configuration as a tree of Kenfigure YAML files — either as a downloadable `.zip` or written directly to your own Git repository. It also includes **schema lint**: heuristic quality checks that flag potential configuration issues before they become problems.
+
+Start free. Keep what you build. Your YAML files live in your own Git repo, in an open format that remains readable and useful regardless of any subscription.
+
+---
+
+## Kenfigure Pro closes the loop
+
+**Kenfigure Pro™** is an annual subscription that adds **Kenfigure Tool™ (Import)** and **Kenfigure Diagram™** — the tools that turn a versioned YAML source of truth into a full configuration-management workflow.
+
+One per-company subscription covers all of your Benchling environments (Dev, Test, Prod, and any Sandbox or Preview tenants). No developer or DevOps engineer required: Kenfigure Pro runs as a Benchling Canvas app and a hosted web application — a Benchling administrator can run the full workflow.
+
+### Kenfigure Tool™ (Import)
+
+Push reviewed, versioned configuration changes back to Benchling without manual UI work.
+
+Instead of translating your YAML back into hundreds of UI clicks — error-prone, time-consuming, and impossible to review before it happens — Kenfigure Tool (Import) generates a Benchling Configuration Migration file from your YAML source of truth and applies it to your tenant. Every import originates from a branch that has been reviewed and approved. Imports are accurate, complete, and fully auditable.
+
+Both **Import from File** (upload a `.zip` of your Kenfigure directory) and **Import from Git** (pull directly from a configured repository branch) are included.
+
+### Kenfigure Diagram™
+
+An interactive entity-relationship diagram of your Benchling configuration — always current, connected to your source of truth.
+
+Kenfigure Diagram visualizes your schema as an explorable graph: filter by schema type, navigate relationships, and search across the entire configuration. Every export you run through Kenfigure Tool automatically refreshes the diagram; you can also point Kenfigure Diagram directly at a Git repository branch for a live view of your YAML.
+
+Schema lint results appear inline as visual indicators — the equivalent of a spell checker for your Benchling data model. Lint suppressions are tracked in Git alongside your configuration.
+
+The **Prompt Builder** assembles rich, targeted context from selected schema elements, ready for SQL query development or AI-assisted analysis. Kenfigure Diagram also integrates with Benchling AI for chat-based schema exploration directly in the interface.
+
+### Git integration throughout
+
+The free Export tier already writes configuration to your Git repository. Kenfigure Pro goes further: Kenfigure Tool (Import) pulls YAML directly from a configured repository branch as its source, and Kenfigure Diagram reads and writes to your repo — saving diagram layouts, sub-layouts, and lint suppressions to a branch of your choice. Configuration, diagram state, and quality decisions all live in one reviewable, versioned place.
+
+---
+
+## Who it's for
+
+**Benchling administrators** who want their configuration under the same discipline as their code — version history, review before changes apply, and a clear record of what changed, when, and why.
+
+**Growing teams investing in Benchling.** The best time to establish good configuration-management practice is before the configuration grows complex. Starting with Kenfigure means building on a solid, reviewable foundation — not trying to reconstruct one after the fact.
+
+**Validated Cloud and GxP teams.** For regulated environments, a versioned source of truth, reviewed changes, and an auditable promotion path through Sandbox/Preview environments to production are not conveniences — they are expectations. Kenfigure provides exactly that workflow. (Validated Cloud is supported across all subscription tiers; [contact us](mailto:info@go2.software) for a tailored quote.)
+
+### Kenfigure Pro and Benchling's Configuration Migration tool
+
+Kenfigure Pro _complements_ Benchling's Configuration Migration tool — it does not replace it. Configuration Migration is the mechanism Benchling provides for applying configuration changes. Kenfigure Pro provides the discipline around it: a versioned source of truth, a structured review step before changes are applied, and a reproducible import process — so every use of Configuration Migration is intentional, traceable, and consistent.
+
+---
+
+## Licensing and pricing
+
+A single per-company subscription covers all of your Benchling environments. Pricing tiers are based on your organization's total Benchling user count — not the number of people who will use Kenfigure directly.
+
+→ [See pricing and tiers](pricing.html)  
+→ [Frequently asked questions](faq.html) — coverage, security, licensing, and support.  
+→ [Feature Support Matrix](feature_matrix.html) — supported Benchling object types for Export, Import, and Diagram.
+
+<a href="pricing.html" class="kf-cta-btn">See pricing →</a>
+
+---
+
+[Back to Kenfigure home](https://kenfigure.com)

--- a/docs/kenfigure_pro.md
+++ b/docs/kenfigure_pro.md
@@ -24,7 +24,7 @@ The configuration-management discipline software teams apply to code — now for
 
 ---
 
-## The problem with Benchling configuration management
+## The challenge of Benchling configuration management
 
 Benchling configuration — entity schemas, dropdowns, result schemas, templates, and more — is complex, evolves constantly, and exists only as UI clicks. There is no version history, no way to propose and review a change before it is applied, no easy path to reproduce a configuration in a new environment, and no visual overview of how everything fits together.
 

--- a/docs/kenfigure_tool_user_guide.md
+++ b/docs/kenfigure_tool_user_guide.md
@@ -451,9 +451,9 @@ The log messages in an expanded session are ordered with the most recent at the 
 
 Every export you run through Kenfigure Tool also makes your configuration immediately available in Kenfigure Diagram.
 
-Kenfigure Diagram is a licensed companion product that renders your Kenfigure configuration as an interactive schema diagram — a fast way to explore the structure of your Benchling environment, share it with your team, and find relationships that are hard to see in a list. If your tenant is provisioned for Kenfigure Diagram, the canvas shows an **Open Kenfigure Diagram** link that takes you directly to your tenant's view.
+Kenfigure Diagram is a part of **[Kenfigure Pro™](kenfigure_pro.html)** that renders your Kenfigure configuration as an interactive schema diagram — a fast way to explore the structure of your Benchling environment, share it with your team, and find relationships that are hard to see in a list. If your tenant is provisioned for Kenfigure Diagram, the canvas shows an **Open Kenfigure Diagram** link that takes you directly to your tenant's view.
 
-Contact [info@go2.software](mailto:info@go2.software) to learn more or to get Kenfigure Diagram set up for your tenant.
+See the [Kenfigure Pro page](kenfigure_pro.html) to learn more, or contact [info@go2.software](mailto:info@go2.software) to get Kenfigure Diagram set up for your tenant.
 
 ---
 
@@ -463,13 +463,13 @@ Contact [info@go2.software](mailto:info@go2.software) to learn more or to get Ke
 | ------------------------- | ------------ |
 | Export to File            | Free for all users |
 | Export to Git             | Free for all users |
-| Import from File          | Premium — see [Feature enablement](https://kenfigure.com/feature_enablement.html) |
-| Import from Git           | Premium — see [Feature enablement](https://kenfigure.com/feature_enablement.html) |
-| Kenfigure Diagram         | Premium — see [Feature enablement](https://kenfigure.com/feature_enablement.html) |
+| Import from File          | Kenfigure Pro™ — see [Kenfigure Pro](kenfigure_pro.html) |
+| Import from Git           | Kenfigure Pro™ — see [Kenfigure Pro](kenfigure_pro.html) |
+| Kenfigure Diagram         | Kenfigure Pro™ — see [Kenfigure Pro](kenfigure_pro.html) |
 
-When a premium feature is not licensed for your tenant, the relevant button in the canvas is disabled and shows a link to the [feature enablement page](https://kenfigure.com/feature_enablement.html) with instructions on how to request access. There is no error message — the canvas simply presents the features that are available.
+When a Kenfigure Pro feature is not licensed for your tenant, the relevant button in the canvas is disabled and shows a link to the [feature enablement page](feature_enablement.html). There is no error message — the canvas simply presents the features that are available.
 
-If the Import buttons are visible but disabled, your tenant has not been provisioned for Import mode. See [Feature enablement](https://kenfigure.com/feature_enablement.html) to request access.
+If the Import buttons are visible but disabled, your tenant has not been provisioned for **Kenfigure Tool (Import)**. See [Feature enablement](feature_enablement.html) or [contact us](mailto:info@go2.software) to request access.
 
 
 ---
@@ -525,4 +525,4 @@ If the error isn't clear, send the log to [info@go2.software](mailto:info@go2.so
 
 ---
 
-[Back to Kenfigure home](https://kenfigure.com) · [Feature enablement](https://kenfigure.com/feature_enablement.html)
+[Back to Kenfigure home](https://kenfigure.com) · [Feature enablement](feature_enablement.html)

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -11,6 +11,8 @@ _Kenfigure is a product of Go2 Software LLC · Last updated: June 2026_
 
 Kenfigure helps Benchling administrators bring their configuration under control — export it to a versionable source of truth, make reviewed changes safely, and understand complex deployments through interactive diagrams. The free **Kenfigure Tool™ (Export)** is available to everyone. **Kenfigure Pro™** adds **Kenfigure Tool (Import)** and **Kenfigure Diagram™** on an annual subscription.
 
+_New to Kenfigure Pro? [Read the product overview](kenfigure_pro.html) to see what's included and who it's for._
+
 <style>
 .pricing-order-btn {
   display: inline-block; margin: 1rem 0;


### PR DESCRIPTION
Fold in references to Kenfigure Pro, create product page, and clean up features/benefits doc.